### PR TITLE
Add demo website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ng-cooltip [![Build Status](https://travis-ci.org/ndelvalle/ng-cooltip.svg?branch=master)](https://travis-ci.org/ndelvalle/ng-cooltip)
+# [ng-cooltip](http://ndelvalle.github.io/ng-cooltip/) [![Build Status](https://travis-ci.org/ndelvalle/ng-cooltip.svg?branch=master)](https://travis-ci.org/ndelvalle/ng-cooltip)
 
 An angular module with a small collection of various hover tooltip. This module is an angular wrapper of [Tooltip Styles Inspiration](https://github.com/codrops/TooltipStylesInspiration).
 


### PR DESCRIPTION
If you go to https://www.npmjs.com/package/ng-cooltip there is no direct link to the demo website.
